### PR TITLE
fix: discoveryserver fetch error fixed

### DIFF
--- a/discoveryServer-dev.yml
+++ b/discoveryServer-dev.yml
@@ -4,6 +4,7 @@ spring:
 eureka:
   client:
     register-with-eureka: false
+    fetch-registry: false
     service-url:
       defaultZone: http://${eureka.instance.hostname}:${server.port}/eureka
   instance:


### PR DESCRIPTION
servis başlatılırken aşağıdaki hatayı veriyordu,
[cloud.spring.io](https://cloud.spring.io/spring-cloud-netflix/multi/multi_spring-cloud-eureka-server.html#spring-cloud-eureka-server-standalone-mode
) daki örnekte olup bizde eksik olan `fetch-registry: false` eklenince düzeliyor
server olduğu için sanırım fetch atmaması gerekiyor

example error below
2024-05-30T04:10:06.596+03:00  INFO 14632 --- [discovery-server] [           main] c.n.d.s.t.d.RedirectingEurekaHttpClient  : Request execution error. endpoint=DefaultEndpoint{ serviceUrl='http://localhost:9000/eureka/}, exception=java.net.ConnectException: Connection refused: getsockopt stacktrace=jakarta.ws.rs.ProcessingException: java.net.ConnectException: Connection refused: getsockopt